### PR TITLE
Fixing documentation about installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ La respuesta carecerá de las frecuencias altas del coseno. fuente: The Scientis
 * MatPlotLib
 * SciPy
 * Numpy
+
+Para instalarlas, se debe ingresar al directorio del proyecto
+
+```bash
+cd PyConvolve
+```
+
+E instalar las dependencias con el siguiente comando:
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+contourpy==1.1.0
+cycler==0.11.0
+fonttools==4.42.0
+kiwisolver==1.4.4
+matplotlib==3.7.2
+numpy==1.25.2
+packaging==23.1
+Pillow==10.0.0
+pyparsing==3.0.9
+python-dateutil==2.8.2
+scipy==1.11.1
+six==1.16.0


### PR DESCRIPTION
# Cambios en la documentacion

Para que sea mas comodo instalar las dependencias sin escribirlas manualmente, se puede utilizar ahora el comando:

```bash
pip install -r requirements.txt
```

Para generar este archivo, es bueno que tengas las dependencias instaladas en el proyecto con un entorno virtual, y ejecutar el siguiente comando:

```bash
pip freeze > requirements.txt
```
de esta manera python automaticamente te generara el archivo con todas las dependencias necesarias.